### PR TITLE
Update BonusStage.au3

### DIFF
--- a/Libraries/BonusStage.au3
+++ b/Libraries/BonusStage.au3
@@ -48,7 +48,7 @@ Func BonusStageDoNoting()
 EndFunc   ;==>BonusStageDoNoting
 
 Func BonusStageFail()
-	PixelSearch(775, 600, 775, 600, 0xB40000, 10)
+	PixelSearch(655, 558, 800, 605, 0xAD0000, 10)
 	If Not @error Then
 		MouseClick("left", 721, 577, 1, 0)
 		WriteInLogs("BonusStage Failed")


### PR DESCRIPTION
Updated the BonusStageFail() function logic to scan for pixels in a wider area and an updated Hex colour value with this line:

PixelSearch(655, 558, 800, 605, 0xAD0000, 10)

Tested locally and working for BS2 on v3.3.7