### PR TITLE
3.4.2 - BS3, logs, hotkeys improvements

### DIFF
--- a/Idle Runner.au3
+++ b/Idle Runner.au3
@@ -101,7 +101,8 @@ Main()
 Func Main()
 	; Set Hotkey Bindings
 	HotKeySet("{Home}", "Pause")
-	HotKeySet("{Esc}", "IdleClose")
+	HotKeySet("+{Esc}", "IdleClose")
+	HotKeySet("^+b", "BuyEquipment")
 	; Create Saving Directory
 	DirCreate("IdleRunnerLogs")
 	; Create GUI

--- a/Libraries/BonusStage.au3
+++ b/Libraries/BonusStage.au3
@@ -18,7 +18,7 @@ Func BonusStage($bSkipBonusStageState)
 	Until @error
 
 	If $bSkipBonusStageState Then
-		BonusStageDoNoting()
+		BonusStageDoNothing($bBonusStage3 ? 3 : 2)
 		Return
 	EndIf
 
@@ -28,42 +28,94 @@ Func BonusStage($bSkipBonusStageState)
 		If $bBonusStage3 Then
 			BonusStage3SB()
 		Else
-			BonusStageSP()
+			BonusStage2SB()
 		EndIf
 	Else
 		If $bBonusStage3 Then
-			BonusStage3NSB()
+			BonusStage3()
 		Else
-			BonusStageNSP()
+			BonusStage2()
 		EndIf
 	EndIf
 EndFunc   ;==>BonusStage
 
-Func BonusStageDoNoting()
-	WriteInLogs("Do noting BonusStage Active")
+Func BonusStageDoNothing($iNumber)
+	WriteInLogs("Do nothing BonusStage Active")
 	Do
 		Sleep(200)
-	Until BonusStageFail()
-EndFunc   ;==>BonusStageDoNoting
+	Until BonusStageFail($iNumber)
+EndFunc   ;==>BonusStageDoNothing
 
-Func BonusStageFail()
+Func BonusStageFail($iNumber)
+	Local $sLogMsg = "BonusStage" & $iNumber & " Failed"
+
 	PixelSearch(780, 600, 780, 600, 0xAD0000)
 	If Not @error Then
 		MouseClick("left", 721, 577, 1, 0)
-		WriteInLogs("BonusStage Failed")
+		WriteInLogs($sLogMsg)
 		Return True
 	EndIf
 	PixelSearch(780, 600, 780, 600, 0xB40000)
 	If Not @error Then
 		MouseClick("left", 721, 577, 1, 0)
-		WriteInLogs("BonusStage Failed")
+		WriteInLogs($sLogMsg)
 		Return True
 	EndIf
 	Return False
 EndFunc   ;==>BonusStageFail
 
-Func BonusStageSP()
-	WriteInLogs("BonusStageSB")
+Func BonusStageRetry($iNumber, $bSpiritBoost)
+	Local $sLogMsg = "BonusStage" & $iNumber & ($bSpiritBoost ? "SB" : "")
+
+	PixelSearch(600, 580, 600, 580, 0x00A800)
+	If Not @error Then
+		MouseClick("left", 560, 600, 1, 0)
+		WriteInLogs($sLogMsg & " Retry")
+		Sleep(1000)
+		Return True
+	EndIf
+
+	Return False
+EndFunc   ;==>BonusStageRetry
+
+Func BonusStage2Fail()
+	Return BonusStageFail(2)
+EndFunc   ;==>BonusStage2Fail
+
+Func BonusStage3Fail($bSpiritBoost)
+	Local $sLogMsg = GetBS3LogText($bSpiritBoost)
+	Local $bRetry = BonusStageRetry(3, $bSpiritBoost)
+
+	If $bRetry Then
+		Return True
+	EndIf
+
+	; Search for Items icon
+	PixelSearch(1130, 604, 1130, 604, 0x989898)
+	If Not @error Then
+		WriteInLogs($sLogMsg & " Failed")
+		Return True
+	EndIf
+
+	; Search for Boost icon
+	PixelSearch(115, 570, 125, 590, 0x09439b)
+	If Not @error Then
+		WriteInLogs($sLogMsg & " Failed")
+		Return True
+	EndIf
+
+	; Search for Wind Rush icon
+	PixelSearch(115, 570, 125, 590, 0x099b66)
+	If Not @error Then
+		WriteInLogs($sLogMsg & " Failed")
+		Return True
+	EndIf
+
+	Return False
+EndFunc   ;==>BonusStage3Fail
+
+Func BonusStage2SB()
+	WriteInLogs("BonusStage2SB")
 	; Section 1 sync
 	FindPixelUntilFound(220, 465, 220, 465, 0xA0938E)
 	Sleep(200)
@@ -79,7 +131,7 @@ Func BonusStageSP()
 	cSend(31, 672) ;4
 	cSend(31, 1700) ;5
 	cSend(94, 5000) ;1
-	If BonusStageFail() Then
+	If BonusStage2Fail() Then
 		Return
 	EndIf
 	; Section 1 Collection
@@ -88,10 +140,10 @@ Func BonusStageSP()
 		Send("{Up}")
 		Sleep(500)
 	Next
-	If BonusStageFail() Then
+	If BonusStage2Fail() Then
 		Return
 	EndIf
-	WriteInLogs("BonusStageBS Section 1 Complete")
+	WriteInLogs("BonusStage2SB Section 1 Complete")
 	; Section 2 sync
 	FindPixelUntilFound(780, 536, 780, 536, 0xBB26DF)
 	; Section 2 start
@@ -118,7 +170,7 @@ Func BonusStageSP()
 	cSend(110, 3000) ;21
 	cSend(360, 2984) ;22
 	cSend(531, 2313) ;23
-	If BonusStageFail() Then
+	If BonusStage2Fail() Then
 		Return
 	EndIf
 	; Section 2 Collection
@@ -127,10 +179,10 @@ Func BonusStageSP()
 		Send("{Up}")
 		Sleep(500)
 	Next
-	If BonusStageFail() Then
+	If BonusStage2Fail() Then
 		Return
 	EndIf
-	WriteInLogs("BonusStageBS Section 2 Complete")
+	WriteInLogs("BonusStage2SB Section 2 Complete")
 	;Stage 3 sync
 	FindPixelUntilFound(220, 465, 220, 465, 0xA0938E)
 	; Section 3 Start
@@ -152,7 +204,7 @@ Func BonusStageSP()
 	cSend(109, 1203) ;13
 	cSend(31, 641) ;14
 	cSend(47, 5125) ;15
-	If BonusStageFail() Then
+	If BonusStage2Fail() Then
 		Return
 	EndIf
 	;Section 3 Collection
@@ -161,10 +213,10 @@ Func BonusStageSP()
 		Send("{Up}")
 		Sleep(500)
 	Next
-	If BonusStageFail() Then
+	If BonusStage2Fail() Then
 		Return
 	EndIf
-	WriteInLogs("BonusStageBS Section 3 Complete")
+	WriteInLogs("BonusStage2SB Section 3 Complete")
 	;Section 4 sync
 	FindPixelUntilFound(250, 472, 100, 250, 0x0D2030)
 	Sleep(200)
@@ -199,14 +251,14 @@ Func BonusStageSP()
 		Send("{Up}")
 		Sleep(500)
 	Next
-	If BonusStageFail() Then
+	If BonusStage2Fail() Then
 		Return
 	EndIf
-	WriteInLogs("BonusStageBS Section 4 Complete")
-EndFunc   ;==>BonusStageSP
+	WriteInLogs("BonusStage2SB Section 4 Complete")
+EndFunc   ;==>BonusStage2SB
 
-Func BonusStageNSP()
-	WriteInLogs("BonusStage")
+Func BonusStage2()
+	WriteInLogs("BonusStage2")
 	; Section 1 sync
 	FindPixelUntilFound(220, 465, 220, 465, 0xA0938E)
 	Sleep(200)
@@ -224,7 +276,7 @@ Func BonusStageNSP()
 	cSend(47, 750) ;11
 	cSend(78, 1203) ;12
 	cSend(110, 5000) ;13
-	If BonusStageFail() Then
+	If BonusStage2Fail() Then
 		Return
 	EndIf
 	; Section 1 Collection
@@ -233,10 +285,10 @@ Func BonusStageNSP()
 		Send("{Up}")
 		Sleep(500)
 	Next
-	If BonusStageFail() Then
+	If BonusStage2Fail() Then
 		Return
 	EndIf
-	WriteInLogs("BonusStage Section 1 Complete")
+	WriteInLogs("BonusStage2 Section 1 Complete")
 	; Section 2 sync
 	FindPixelUntilFound(780, 536, 780, 536, 0xBB26DF)
 	; Section 2 start
@@ -263,7 +315,7 @@ Func BonusStageNSP()
 	cSend(110, 3000) ;21
 	cSend(360, 2984) ;22
 	cSend(531, 2313) ;23
-	If BonusStageFail() Then
+	If BonusStage2Fail() Then
 		Return
 	EndIf
 	; Section 2 Collection
@@ -272,10 +324,10 @@ Func BonusStageNSP()
 		Send("{Up}")
 		Sleep(500)
 	Next
-	If BonusStageFail() Then
+	If BonusStage2Fail() Then
 		Return
 	EndIf
-	WriteInLogs("BonusStage Section 2 Complete")
+	WriteInLogs("BonusStage2 Section 2 Complete")
 	;Stage 3 sync
 	FindPixelUntilFound(220, 465, 220, 465, 0xA0938E)
 	; Section 3 Start
@@ -297,7 +349,7 @@ Func BonusStageNSP()
 	cSend(109, 1203) ;13
 	cSend(31, 641) ;14
 	cSend(47, 5125) ;15
-	If BonusStageFail() Then
+	If BonusStage2Fail() Then
 		Return
 	EndIf
 	;Section 3 Collection
@@ -306,10 +358,10 @@ Func BonusStageNSP()
 		Send("{Up}")
 		Sleep(500)
 	Next
-	If BonusStageFail() Then
+	If BonusStage2Fail() Then
 		Return
 	EndIf
-	WriteInLogs("BonusStage Section 3 Complete")
+	WriteInLogs("BonusStage2 Section 3 Complete")
 	;Section 4 sync
 	FindPixelUntilFound(250, 472, 100, 250, 0x0D2030)
 	Sleep(200)
@@ -336,49 +388,101 @@ Func BonusStageNSP()
 		Send("{Up}")
 		Sleep(500)
 	Next
-	If BonusStageFail() Then
+	If BonusStage2Fail() Then
 		Return
 	EndIf
-	WriteInLogs("BonusStage Section 4 Complete")
-EndFunc   ;==>BonusStageNSP
+	WriteInLogs("BonusStage2 Section 4 Complete")
+EndFunc   ;==>BonusStage2
 
-Func BonusStage3NSB()
-	WriteInLogs("BonusStage3")
+Func BonusStage3($iCurrentSection = 0)
+	Local $iTotalSections = 4
 
-	If Not BonusStage3Section1() Then
-		Return
-	EndIf
-	If Not BonusStage3Section2() Then
-		Return
-	EndIf
-	If Not BonusStage3Section3() Then
-		Return
-	EndIf
-	If Not BonusStage3Section4() Then
+	If $iCurrentSection == 0 Then
+		WriteInLogs("BonusStage3")
+	ElseIf $iCurrentSection >= 2 * $iTotalSections Then
 		Return
 	EndIf
 
-EndFunc   ;==>BonusStage3NSB
+	Local $iSection = Mod($iCurrentSection, $iTotalSections)
 
-Func BonusStage3SB()
-	WriteInLogs("BonusStage3SB")
+	If $iSection == 0 Then
+		If Not BonusStage3Section1() Then
+			BonusStage3($iCurrentSection + $iTotalSections)
+			Return
+		EndIf
+		$iCurrentSection += 1
+		$iSection = 1
+	EndIf
+	If $iSection == 1 Then
+		If Not BonusStage3Section2() Then
+			BonusStage3($iCurrentSection + $iTotalSections)
+			Return
+		EndIf
+		$iCurrentSection += 1
+		$iSection = 2
+	EndIf
+	If $iSection == 2 Then
+		If Not BonusStage3Section3() Then
+			BonusStage3($iCurrentSection + $iTotalSections)
+			Return
+		EndIf
+		$iCurrentSection += 1
+		$iSection = 3
+	EndIf
+	If $iSection == 3 Then
+		If Not BonusStage3Section4() Then
+			BonusStage3($iCurrentSection + $iTotalSections)
+			Return
+		EndIf
+	EndIf
 
-	If Not BonusStage3Section1() Then
+EndFunc   ;==>BonusStage3
+
+Func BonusStage3SB($iCurrentSection = 0)
+	Local $iTotalSections = 4
+
+	If $iCurrentSection == 0 Then
+		WriteInLogs("BonusStage3SB")
+	ElseIf $iCurrentSection >= 2 * $iTotalSections Then
 		Return
 	EndIf
-	If Not BonusStage3Section2() Then
-		Return
+
+	Local $iSection = Mod($iCurrentSection, $iTotalSections)
+
+	If $iSection == 0 Then
+		If Not BonusStage3Section1(True) Then
+			BonusStage3SB($iCurrentSection + $iTotalSections)
+			Return
+		EndIf
+		$iCurrentSection += 1
+		$iSection = 1
 	EndIf
-	If Not BonusStage3Section3(True) Then
-		Return
+	If $iSection == 1 Then
+		If Not BonusStage3Section2(True) Then
+			BonusStage3SB($iCurrentSection + $iTotalSections)
+			Return
+		EndIf
+		$iCurrentSection += 1
+		$iSection = 2
 	EndIf
-	If Not BonusStage3Section4(True) Then
-		Return
+	If $iSection == 2 Then
+		If Not BonusStage3Section3(True) Then
+			BonusStage3SB($iCurrentSection + $iTotalSections)
+			Return
+		EndIf
+		$iCurrentSection += 1
+		$iSection = 3
+	EndIf
+	If $iSection == 3 Then
+		If Not BonusStage3Section4(True) Then
+			BonusStage3SB($iCurrentSection + $iTotalSections)
+			Return
+		EndIf
 	EndIf
 
 EndFunc   ;==>BonusStage3SB
 
-Func BonusStage3Section1()
+Func BonusStage3Section1($bSpiritBoost = False)
 	; Section 1 sync
 	FindPixelUntilFound(520, 200, 580, 250, 0xFFFFFF)
 	Sleep(360)
@@ -394,10 +498,12 @@ Func BonusStage3Section1()
 	cSend(150, 750) ;7
 	cSend(200, 200) ;8
 
-	FindPixelUntilFound(390, 230, 410, 250, 0xFFFFFF, 1400)
+	FindPixelUntilFound(390, 230, 410, 250, 0xFFFFFF, 3500)
 	cSend(130, 545) ;9
 	cSend(70, 620) ;10
-	cSend(80, 720) ;11
+	cSend(80, 400) ;11
+	FindPixelUntilFound(500, 200, 515, 250, 0xFFFFFF, 1500)
+
 	cSend(150, 755) ;12
 	cSend(65, 625) ;13
 	cSend(65, 500) ;14
@@ -416,7 +522,7 @@ Func BonusStage3Section1()
 
 	Sleep(800)
 
-	If BonusStageFail() Then
+	If BonusStage3Fail($bSpiritBoost) Then
 		Return False
 	EndIf
 	; Section 1 Collection
@@ -424,14 +530,16 @@ Func BonusStage3Section1()
 		Send("{Up}")
 		Sleep(500)
 	Next
-	If BonusStageFail() Then
+	If BonusStage3Fail($bSpiritBoost) Then
 		Return False
 	EndIf
-	WriteInLogs("BonusStage Section 1 Complete")
+
+	WriteInLogs(GetBS3LogText($bSpiritBoost) " Section 1 Complete")
+
 	Return True
 EndFunc   ;==>BonusStage3Section1
 
-Func BonusStage3Section2()
+Func BonusStage3Section2($bSpiritBoost = False)
 	; Section 2 sync
 	Sleep(1000)
 	FindPixelUntilFound(306, 200, 309, 275, 0xFFFFFF)
@@ -466,7 +574,7 @@ Func BonusStage3Section2()
 	cSend(80, 440)
 	cSend(95, 660)
 
-	If BonusStageFail() Then
+	If BonusStage3Fail($bSpiritBoost) Then
 		Return False
 	EndIf
 	; Section 2 Collection
@@ -474,14 +582,14 @@ Func BonusStage3Section2()
 		Send("{Up}")
 		Sleep(500)
 	Next
-	If BonusStageFail() Then
+	If BonusStage3Fail($bSpiritBoost) Then
 		Return False
 	EndIf
-	WriteInLogs("BonusStage Section 2 Complete")
+	WriteInLogs(GetBS3LogText($bSpiritBoost) & " Section 2 Complete")
 	Return True
 EndFunc   ;==>BonusStage3Section2
 
-Func BonusStage3Section3($isSpiritBoost = False)
+Func BonusStage3Section3($bSpiritBoost = False)
 	Local $bUpperWay = False
 	;Stage 3 sync
 	FindPixelUntilFound(280, 385, 330, 435, 0xFFFFFF)
@@ -511,7 +619,7 @@ Func BonusStage3Section3($isSpiritBoost = False)
 			BonusStage3WallJump(1, 715) ;8
 			BonusStage3WallJump(6) ;9
 
-			Local $bFound = FindPixelUntilFound(300, 415, 330, 435, 0xFFFFFF, $isSpiritBoost ? 1000 : 2500)
+			Local $bFound = FindPixelUntilFound(300, 415, 330, 435, 0xFFFFFF, $bSpiritBoost ? 1000 : 2500)
 			If $bFound == False Then
 				$bUpperWay = True
 			Else
@@ -522,7 +630,7 @@ Func BonusStage3Section3($isSpiritBoost = False)
 		EndIf
 	Next
 
-	If BonusStageFail() Then
+	If BonusStage3Fail($bSpiritBoost) Then
 		Return False
 	EndIf
 	;Section 3 Collection
@@ -530,10 +638,10 @@ Func BonusStage3Section3($isSpiritBoost = False)
 		Send("{Up}")
 		Sleep(500)
 	Next
-	If BonusStageFail() Then
+	If BonusStage3Fail($bSpiritBoost) Then
 		Return False
 	EndIf
-	WriteInLogs("BonusStage Section 3 Complete")
+	WriteInLogs(GetBS3LogText($bSpiritBoost) & " Section 3 Complete")
 	Return True
 EndFunc   ;==>BonusStage3Section3
 
@@ -543,28 +651,29 @@ Func BonusStage3WallJump($iCount = 5, $iSleep = 50)
 	Next
 EndFunc   ;==>BonusStage3WallJump
 
-Func BonusStage3Section4($isSpiritBoost = False)
-	Local $iSpiritBoostHold = $isSpiritBoost ? 100 : 300
+Func BonusStage3Section4($bSpiritBoost = False)
 	;Section 4 sync
 	FindPixelUntilFound(330, 170, 380, 195, 0xFFFFFF)
 	;Section 4 Starts
-	For $iX = 1 To 5
-		cSend($iSpiritBoostHold, 900 - $iSpiritBoostHold) ;1
-		cSend(300, 420) ;2
+	If Not $bSpiritBoost Then
+		For $iX = 1 To 5
+			cSend(300, 600) ;1
 
-		If $isSpiritBoost == False Then
+			cSend(300, 420) ;2
+
 			cSend(35, 748) ;3
-
 			cSend(35, 540) ;4
 			cSend(35, 1160) ;5s
-		EndIf
-	Next
+		Next
+	Else
+		For $iX = 1 To 14
+			cSend(110, 1180) ;1
+		Next
 
-	If $isSpiritBoost Then
 		cSend(300, 300)
 	EndIf
 
-	If BonusStageFail() Then
+	If BonusStage3Fail($bSpiritBoost) Then
 		Return False
 	EndIf
 	;Section 4 Collection
@@ -572,9 +681,13 @@ Func BonusStage3Section4($isSpiritBoost = False)
 		Send("{Up}")
 		Sleep(500)
 	Next
-	If BonusStageFail() Then
+	If BonusStage3Fail($bSpiritBoost) Then
 		Return False
 	EndIf
-	WriteInLogs("BonusStage Section 4 Complete")
+	WriteInLogs(GetBS3LogText($bSpiritBoost) & " Section 4 Complete")
 	Return True
 EndFunc   ;==>BonusStage3Section4
+
+Func GetBS3LogText($bSpiritBoost)
+	Return "BonusStage3" & ($bSpiritBoost ? "SB" : "")
+EndFunc   ;==>GetBS3LogText

--- a/Libraries/BonusStage.au3
+++ b/Libraries/BonusStage.au3
@@ -534,7 +534,7 @@ Func BonusStage3Section1($bSpiritBoost = False)
 		Return False
 	EndIf
 
-	WriteInLogs(GetBS3LogText($bSpiritBoost) " Section 1 Complete")
+	WriteInLogs(GetBS3LogText($bSpiritBoost) & " Section 1 Complete")
 
 	Return True
 EndFunc   ;==>BonusStage3Section1

--- a/Libraries/GUI.au3
+++ b/Libraries/GUI.au3
@@ -28,7 +28,7 @@ Global $bAutoBuyUpgradeState = False, _
 		$bAutoAscendState = False, _
 		$bTogglePause = False
 
-Global $sVersion = "3.4.1"
+Global $sVersion = "3.4.2"
 Global $iJumpSliderValue = 150, _
 		$iCirclePortalsCount = 7, _
 		$iAutoAscendTimer = 10, _

--- a/Libraries/Log.au3
+++ b/Libraries/Log.au3
@@ -10,10 +10,12 @@
 ; ===============================================================================================================================
 Func LoadLog($iLog)
 	Sleep(100)
-	Local $iSection1 = 0, $iSection2 = 0, $iSection3 = 0, $iSection4 = 0, $iChesthunt = 0, $iFailed = 0, _
-			$iMinionsClaimed = 0, $iQuestClaimed = 0, $iSection1BS = 0, $iSection2BS = 0, $iSection3BS = 0, $iSection4BS = 0, _
-			$iSilverboxColl = 0, $iBonusStage = 0, $iBonusStageSP = 0, $iMegaHordeRage = 0, $iMegaHordeRageSoul = 0, $iBossFightVictorWon = 0, _
-			$iBossFightVictor = 0, $iBossFightKnightWon = 0, $iBossFightKnight = 0, $iAscendingHeights = 0, $iAscendingHeightsFailed = 0
+	Local $iBS2Section1 = 0, $iBS2Section2 = 0, $iBS2Section3 = 0, $iBS2Section4 = 0, $iBS2Failed = 0, _
+			$iBS2Section1SB = 0, $iBS2Section2SB = 0, $iBS2Section3SB = 0, $iBS2Section4SB = 0, $iBonusStage2 = 0, $iBonusStage2SB = 0, _
+			$iBS3Section1 = 0, $iBS3Section2 = 0, $iBS3Section3 = 0, $iBS3Section4 = 0, $iBS3Failed = 0, $iBS3FailedSB = 0, $iBS3Retried = 0, $iBS3RetriedSB = 0, _
+			$iBS3Section1SB = 0, $iBS3Section2SB = 0, $iBS3Section3SB = 0, $iBS3Section4SB = 0, $iBonusStage3 = 0, $iBonusStage3SB = 0, _
+			$iMinionsClaimed = 0, $iQuestClaimed = 0, $iSilverboxColl = 0, $iMegaHordeRage = 0, $iMegaHordeRageSoul = 0, $iChesthunt = 0, _
+			$iBossFightVictorWon = 0, $iBossFightVictor = 0, $iBossFightKnightWon = 0, $iBossFightKnight = 0, $iAscendingHeights = 0, $iAscendingHeightsFailed = 0
 	Local $hFile = FileOpen("IdleRunnerLogs\Logs.txt", $FO_READ)
 	If $hFile <> -1 Then
 		While 1
@@ -21,26 +23,6 @@ Func LoadLog($iLog)
 			If @error = -1 Then ExitLoop
 			$sLine = StringTrimLeft($sLine, 22)
 			Switch $sLine
-				Case "Start of Ascending Heights"
-					$iAscendingHeights += 1
-				Case "Ascending Height Failed"
-					$iAscendingHeightsFailed += 1
-				Case "BonusStageBS Section 1 Complete"
-					$iSection1BS += 1
-				Case "BonusStageBS Section 2 Complete"
-					$iSection2BS += 1
-				Case "BonusStageBS Section 3 Complete"
-					$iSection3BS += 1
-				Case "BonusStageBS Section 4 Complete"
-					$iSection4BS += 1
-				Case "BonusStage Section 1 Complete"
-					$iSection1 += 1
-				Case "BonusStage Section 2 Complete"
-					$iSection2 += 1
-				Case "BonusStage Section 3 Complete"
-					$iSection3 += 1
-				Case "BonusStage Section 4 Complete"
-					$iSection4 += 1
 				Case "Silver Box Collected"
 					$iSilverboxColl += 1
 				Case "Minions Collect"
@@ -49,18 +31,66 @@ Func LoadLog($iLog)
 					$iMinionsClaimed += 1
 				Case "Chesthunt"
 					$iChesthunt += 1
-				Case "BonusStage Failed"
-					$iFailed += 1
-				Case "BonusStage"
-					$iBonusStage += 1
-				Case "BonusStageSB"
-					$iBonusStageSP += 1
 				Case "Claiming quest"
 					$iQuestClaimed += 1
 				Case "MegaHorde Rage"
 					$iMegaHordeRage += 1
 				Case "MegaHorde Rage with SoulBonus"
 					$iMegaHordeRageSoul += 1
+				Case "BonusStage2SB Section 1 Complete"
+					$iBS2Section1SB += 1
+				Case "BonusStage2SB Section 2 Complete"
+					$iBS2Section2SB += 1
+				Case "BonusStage2SB Section 3 Complete"
+					$iBS2Section3SB += 1
+				Case "BonusStage2SB Section 4 Complete"
+					$iBS2Section4SB += 1
+				Case "BonusStage2 Section 1 Complete"
+					$iBS2Section1 += 1
+				Case "BonusStage2 Section 2 Complete"
+					$iBS2Section2 += 1
+				Case "BonusStage2 Section 3 Complete"
+					$iBS2Section3 += 1
+				Case "BonusStage2 Section 4 Complete"
+					$iBS2Section4 += 1
+				Case "BonusStage2 Failed"
+					$iBS2Failed += 1
+				Case "BonusStage2"
+					$iBonusStage2 += 1
+				Case "BonusStage2SB"
+					$iBonusStage2SB += 1
+				Case "BonusStage3SB Section 1 Complete"
+					$iBS3Section1SB += 1
+				Case "BonusStage3SB Section 2 Complete"
+					$iBS3Section2SB += 1
+				Case "BonusStage3SB Section 3 Complete"
+					$iBS3Section3SB += 1
+				Case "BonusStage3SB Section 4 Complete"
+					$iBS3Section4SB += 1
+				Case "BonusStage3 Section 1 Complete"
+					$iBS3Section1 += 1
+				Case "BonusStage3 Section 2 Complete"
+					$iBS3Section2 += 1
+				Case "BonusStage3 Section 3 Complete"
+					$iBS3Section3 += 1
+				Case "BonusStage3 Section 4 Complete"
+					$iBS3Section4 += 1
+				Case "BonusStage3 Failed"
+					$iBS3Failed += 1
+				Case "BonusStage3SB Failed"
+					$iBS3FailedSB += 1
+				Case "BonusStage3 Retry"
+					$iBS3Retried += 1
+				Case "BonusStage3SB Retry"
+					$iBS3RetriedSB += 1
+				Case "BonusStage3"
+					$iBonusStage3 += 1
+				Case "BonusStage3SB"
+					$iBonusStage3SB += 1
+				Case "Start of Ascending Heights"
+					$iAscendingHeights += 1
+				Case "Ascending Height Failed"
+					$iAscendingHeightsFailed += 1
 				Case "Start of BossFight Victor"
 					$iBossFightVictor += 1
 				Case "Victor Won"
@@ -73,6 +103,18 @@ Func LoadLog($iLog)
 		WEnd
 		FileClose($hFile)
 	EndIf
+
+	Local $iBS2TotalAttempts = $iBonusStage2 + $iBonusStage2SB
+	Local $iBS2TotalCompletes = $iBS2Section4 + $iBS2Section4SB
+	Local $iBS2SuccessPerc = $iBS2TotalAttempts == 0 ? 0 : Round($iBS2TotalCompletes / $iBS2TotalAttempts * 100, 2)
+
+	Local $iBS3TotalAttempts = $iBonusStage3 + $iBonusStage3SB
+	Local $iBS3TotalCompletes = $iBS3Section4 + $iBS3Section4SB
+	Local $iBS3SuccessPerc = $iBS3TotalAttempts == 0 ? 0 : Round($iBS3TotalCompletes / $iBS3TotalAttempts * 100, 2)
+
+	Local $iBS3TotalFails = $iBS3Failed + $iBS3FailedSB
+	Local $iBS3TotalRetried = $iBS3Retried + $iBS3RetriedSB
+
 	GUICtrlSetData($iLog, "")
 	CustomConsole($iLog, "Rage with only MegaHorde: " & $iMegaHordeRage - $iMegaHordeRageSoul)
 	CustomConsole($iLog, "Rage with MegaHorde and SoulBonus: " & $iMegaHordeRageSoul)
@@ -80,20 +122,45 @@ Func LoadLog($iLog)
 	CustomConsole($iLog, "Claimed Minions: " & $iMinionsClaimed)
 	CustomConsole($iLog, "ChestHunts: " & $iChesthunt)
 	CustomConsole($iLog, "Collected SilverBoxes: " & $iSilverboxColl)
-	CustomConsole($iLog, "Failed Bonus Stages: " & $iFailed)
-	CustomConsole($iLog, "BonusStage (No Spirit Boost): " & $iBonusStage)
-	CustomConsole($iLog, "BonusStage (Spirit Boost): " & $iBonusStageSP)
-	CustomConsole($iLog, "Section 1 Complete (No Spirit Boost): " & $iSection1)
-	CustomConsole($iLog, "Section 2 Complete (No Spirit Boost): " & $iSection2)
-	CustomConsole($iLog, "Section 3 Complete (No Spirit Boost): " & $iSection3)
-	CustomConsole($iLog, "Section 4 Complete (No Spirit Boost): " & $iSection4)
-	CustomConsole($iLog, "Section 1 Complete (Spirit Boost): " & $iSection1BS)
-	CustomConsole($iLog, "Section 2 Complete (Spirit Boost): " & $iSection2BS)
-	CustomConsole($iLog, "Section 3 Complete (Spirit Boost): " & $iSection3BS)
-	CustomConsole($iLog, "Section 3 Complete (Spirit Boost): " & $iSection3BS)
-	CustomConsole($iLog, "Section 4 Complete (Spirit Boost): " & $iSection4BS)
+	CustomConsole($iLog, "---------------------BONUS-STAGE-2----------------------")
+	CustomConsole($iLog, "Total Attempts: " & $iBS2TotalAttempts)
+	CustomConsole($iLog, "Total Completes: " & $iBS2TotalCompletes)
+	CustomConsole($iLog, "Failed: " & $iBS2Failed)
+	CustomConsole($iLog, "Success: " & $iBS2SuccessPerc & "%")
+	CustomConsole($iLog, "BS2: Attempts (No Spirit Boost): " & $iBonusStage2)
+	CustomConsole($iLog, "BS2: Attempts (Spirit Boost): " & $iBonusStage2SB)
+	CustomConsole($iLog, "BS2: Completes (No Spirit Boost): " & $iBS2Section4)
+	CustomConsole($iLog, "BS2: Completes (Spirit Boost): " & $iBS2Section4SB)
+	CustomConsole($iLog, "BS2: Section 1 Complete (No Spirit Boost): " & $iBS2Section1)
+	CustomConsole($iLog, "BS2: Section 2 Complete (No Spirit Boost): " & $iBS2Section2)
+	CustomConsole($iLog, "BS2: Section 3 Complete (No Spirit Boost): " & $iBS2Section3)
+	CustomConsole($iLog, "BS2: Section 4 Complete (No Spirit Boost): " & $iBS2Section4)
+	CustomConsole($iLog, "BS2: Section 1 Complete (Spirit Boost): " & $iBS2Section1SB)
+	CustomConsole($iLog, "BS2: Section 2 Complete (Spirit Boost): " & $iBS2Section2SB)
+	CustomConsole($iLog, "BS2: Section 3 Complete (Spirit Boost): " & $iBS2Section3SB)
+	CustomConsole($iLog, "BS2: Section 4 Complete (Spirit Boost): " & $iBS2Section4SB)
+	CustomConsole($iLog, "---------------------BONUS-STAGE-3----------------------")
+	CustomConsole($iLog, "Total Attempts: " & $iBS3TotalAttempts)
+	CustomConsole($iLog, "Total Completes: " & $iBS3TotalCompletes)
+	CustomConsole($iLog, "Retried: " & $iBS3TotalRetried)
+	CustomConsole($iLog, "Failed: " & $iBS3TotalFails)
+	CustomConsole($iLog, "Success: " & $iBS3SuccessPerc & "%")
+	CustomConsole($iLog, "BS3: Attempts (No Spirit Boost): " & $iBonusStage3)
+	CustomConsole($iLog, "BS3: Attempts (Spirit Boost): " & $iBonusStage3SB)
+	CustomConsole($iLog, "BS3: Completes (No Spirit Boost): " & $iBS3Section4)
+	CustomConsole($iLog, "BS3: Completes (Spirit Boost): " & $iBS3Section4SB)
+	CustomConsole($iLog, "BS3: Section 1 Complete (No Spirit Boost): " & $iBS3Section1)
+	CustomConsole($iLog, "BS3: Section 2 Complete (No Spirit Boost): " & $iBS3Section2)
+	CustomConsole($iLog, "BS3: Section 3 Complete (No Spirit Boost): " & $iBS3Section3)
+	CustomConsole($iLog, "BS3: Section 4 Complete (No Spirit Boost): " & $iBS3Section4)
+	CustomConsole($iLog, "BS3: Section 1 Complete (Spirit Boost): " & $iBS3Section1SB)
+	CustomConsole($iLog, "BS3: Section 2 Complete (Spirit Boost): " & $iBS3Section2SB)
+	CustomConsole($iLog, "BS3: Section 3 Complete (Spirit Boost): " & $iBS3Section3SB)
+	CustomConsole($iLog, "BS3: Section 4 Complete (Spirit Boost): " & $iBS3Section4SB)
+	CustomConsole($iLog, "-------------------ASCENDING-HEIGHTS--------------------")
 	CustomConsole($iLog, "Ascending Heights Won : " & $iAscendingHeights - $iAscendingHeightsFailed)
 	CustomConsole($iLog, "Ascending Heights Failed : " & $iAscendingHeightsFailed)
+	CustomConsole($iLog, "----------------------BOSS-FIGHTS-----------------------")
 	CustomConsole($iLog, "Victor Fights Done: " & $iBossFightVictor)
 	CustomConsole($iLog, "Victor Fights Won: " & $iBossFightVictorWon)
 	CustomConsole($iLog, "Victor Fights Lost: " & $iBossFightVictor - $iBossFightVictorWon)
@@ -122,8 +189,8 @@ Func LoadDataLog($iLogData)
 	Else
 		CustomConsole($iLogData, "Idle Slayer not Active")
 	EndIf
-	CustomConsole($iLogData, "Only Bonus Stage 2 works otherwise skip it.")
-	CustomConsole($iLogData, "Disable Hard Mode")
+	CustomConsole($iLogData, "Only Bonus Stage 2 and 3 works otherwise skip it.")
+	CustomConsole($iLogData, "Disable Hard Mode for Bonus Stage 2.")
 	CustomConsole($iLogData, "Do not buy Vertical Magnet.")
 	CustomConsole($iLogData, "Disable dialogue for Portal in setting.")
 	CustomConsole($iLogData, "Enable rounded bulk in setting.")
@@ -131,12 +198,14 @@ Func LoadDataLog($iLogData)
 	CustomConsole($iLogData, "The game must be in English.")
 	CustomConsole($iLogData, "Game must be in focus.")
 	CustomConsole($iLogData, "Ascension Upgrade Leadership Master is mandatory.")
-	CustomConsole($iLogData, "Ascension Upgrade Safety First is mandatory.")
-	CustomConsole($iLogData, "Use Roy/Anna if for Victor and Ascending Heights.")
+	CustomConsole($iLogData, "Ascension Upgrade Protect is mandatory for Bonus Stage 2.")
+	CustomConsole($iLogData, "Ascension Upgrade Board The Platforms is mandatory for")
+	CustomConsole($iLogData, "       Bonus Stage 3.")
+	CustomConsole($iLogData, "Use Roy/Anna for Victor and Ascending Heights.")
 	CustomConsole($iLogData, "Run the script as Administrator in Windows 11.")
 	CustomConsole($iLogData, "Disable custom cursor in setting.")
-	CustomConsole($iLogData, "Tip: Hover over the Text-Boxes_")
-	CustomConsole($iLogData, "on the Idle Runner to read what they do!", True)
+	CustomConsole($iLogData, "Tip: Hover over the Text-Boxes")
+	CustomConsole($iLogData, "       on the Idle Runner to read what they do!", True)
 EndFunc   ;==>LoadDataLog
 
 Func CustomConsole($iComponent, $sText, $bAppend = False)


### PR DESCRIPTION
Added:
- Hotkey `Ctrl+Shift+B` to autobuy once.
- Now retries instead of exiting on Bonus Stage 3.

Updated:
- Exit script hotkey changed from `Esc` to `Shift+Esc` to make it more specific and not override other programs escape key.
- Logs are now more up to date. Updated logs stats with more distinct sections. **WARNING!:** will break the bonus stage statistics, so logs should be cleared by the user. 
- Improved Bonus Stage 3 Spirit Boost success rate (section 4).
- Improved Bonus Stage 3 section 1 to fail less.