### PR TITLE
Fixed Crash when trying to craft temp items without the required materials

### DIFF
--- a/Idle Runner.au3
+++ b/Idle Runner.au3
@@ -343,13 +343,13 @@ Func BuyTempItem($sHexColor)
 		MouseClick("left", $aFoundPixel[0], $aFoundPixel[1], 1, 0)
 		Sleep(200)
 		MouseClick("left", 407, 213, 1, 0)
-		; Close 
-		MouseClick("left", 440, 690, 1, 0)
-		Sleep(100)
 		WriteInLogs("CraftingTemp Item Active")
 	Else
 		WriteInLogs("CraftingTemp Item Failed, not enough materials")
 	EndIf
+	; Close 
+	MouseClick("left", 440, 690, 1, 0)
+	Sleep(100)
 EndFunc   ;==>BuyTempItem
 
 Func AutoAscend()

--- a/Idle Runner.au3
+++ b/Idle Runner.au3
@@ -329,7 +329,7 @@ Func CheckForSoulBonus()
 EndFunc   ;==>CheckForSoulBonus
 
 Func BuyTempItem($sHexColor)
-	WriteInLogs("CraftingTemp Item Active")
+	WriteInLogs("Trying to CraftingTemp Item")
 	Local $aFoundPixel
 	;open menu
 	MouseClick("left", 160, 100, 1, 0)
@@ -339,12 +339,17 @@ Func BuyTempItem($sHexColor)
 	Sleep(150)
 
 	$aFoundPixel = PixelSearch(43, 330, 625, 630, $sHexColor)
-	MouseClick("left", $aFoundPixel[0], $aFoundPixel[1], 1, 0)
-	Sleep(200)
-	MouseClick("left", 407, 213, 1, 0)
-	; Close 
-	MouseClick("left", 440, 690, 1, 0)
-	Sleep(100)
+	If Not @error Then
+		MouseClick("left", $aFoundPixel[0], $aFoundPixel[1], 1, 0)
+		Sleep(200)
+		MouseClick("left", 407, 213, 1, 0)
+		; Close 
+		MouseClick("left", 440, 690, 1, 0)
+		Sleep(100)
+		WriteInLogs("CraftingTemp Item Active")
+	Else
+		WriteInLogs("CraftingTemp Item Failed, not enough materials")
+	EndIf
 EndFunc   ;==>BuyTempItem
 
 Func AutoAscend()

--- a/Idle Runner.au3
+++ b/Idle Runner.au3
@@ -309,7 +309,7 @@ Func Rage()
 		BuyTempItem("0x526629")
 		$bBiDimensionalState = False
 		If Not @Compiled Then
-			GUICtrlSetImage($iCheckBoxbDimensionalState, 'Resources\CheckboxChecked.jpg')
+			GUICtrlSetImage($iCheckBoxbDimensionalState, 'Resources\CheckboxUnchecked.jpg')
 		Else
 			_Resource_SetToCtrlID($iCheckBoxbBiDimensionalState, 'UNCHECKED')
 		EndIf


### PR DESCRIPTION
As wirtten in #bug-report the game crashes when trying to craft a temp item without having enough materials to craft them.
This is easily caught by adding a If not @error, added console output that says item couldnt be crafted.
Also some inconsistency in the not @compiled part which should only matter for testing uncompiled scripts.
Have tested the temp item fix and it works wonderfully. 
![image](https://github.com/user-attachments/assets/98ba4d78-7519-4a57-a816-d4513e82ea85)
